### PR TITLE
Fix warnings

### DIFF
--- a/performance_curve.R
+++ b/performance_curve.R
@@ -85,7 +85,7 @@ divisibility_bench <- function(size)
 	for (n in 1:10)
 	{
 		moduli <- list_cycle(size)
-		total <- total + system.time(data %% moduli)
+		total <- total + system.time(data %% moduli)[1]
 	}
 
 	return(total)
@@ -152,7 +152,7 @@ unsorted_linear_search <- function(size)
 	data <- rep(FALSE,size)
 	data[sample(1:size,1)] <- TRUE
 
-	return(system.time(for (i in data) {if(i){break}}))[1]
+	return((system.time(for (i in data) {if(i){break}}))[1])
 }
 
 #


### PR DESCRIPTION
divisibility_bench accumulated all members of `system.time` rather than just the CPU time. Extracting only the CPU time squashes warnings about different size replacements when divisibility_bench returns.

unsorted_linear_bench needed more bracketing. Together, this eliminates warnings.